### PR TITLE
Use API to fetch latest product data

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,9 +32,12 @@ const getFileSha = async () => {
 // Endpoint to get product data
 app.get('/api/data', async (req, res) => {
   try {
-    const url = `https://raw.githubusercontent.com/${GITHUB_REPO}/main/${DATA_FILE_PATH}`;
-    const response = await axios.get(url);
-    res.json(response.data);
+    const url = `https://api.github.com/repos/${GITHUB_REPO}/contents/${DATA_FILE_PATH}?ref=main`;
+    const response = await axios.get(url, {
+      headers: GITHUB_TOKEN ? { 'Authorization': `token ${GITHUB_TOKEN}` } : {}
+    });
+    const fileContent = Buffer.from(response.data.content, 'base64').toString('utf-8');
+    res.json(JSON.parse(fileContent));
   } catch (error) {
     if (error.response && error.response.status === 404) {
       res.json({}); // Return empty object if file not found


### PR DESCRIPTION
## Summary
- read product data from `api.github.com` instead of `raw.githubusercontent.com`

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685f2cd40a78832f828233e9ef3b802e